### PR TITLE
Setting for nofile ulimit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class nexus (
   $service_options       = $::nexus::params::service_options,
   $service_ensure        = $::nexus::params::service_ensure,
   $service_enable        = $::nexus::params::service_enable,
+  $nofile_limit          = $::nexus::params::nofile_limit,
 ) inherits ::nexus::params {
 
   case $version {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,5 +39,6 @@ class nexus::params {
   $service_script   = '/etc/systemd/system/nexus.service'
   $service_template = 'nexus/nexus.systemd.erb'
   $service_options  = {}
+  $nofile_limit     = 65536
 
 }

--- a/templates/nexus.systemd.erb
+++ b/templates/nexus.systemd.erb
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+LimitNOFILE=<%= scope.lookupvar('::nexus::nofile_limit') %>
 ExecStart=<%= scope.lookupvar('::nexus::user_home') %>/nexus/bin/nexus start
 ExecStop=<%= scope.lookupvar('::nexus::user_home') %>/nexus/bin/nexus stop
 User=<%= scope.lookupvar('::nexus::nexus_user') %>


### PR DESCRIPTION
Added support for setting the nofile ulimit value for the Nexus systemd service.  The default value is that suggested by Sonatype for Nexus 3.

See also: https://help.sonatype.com/repomanager3/system-requirements#filehandles